### PR TITLE
Fixing types and case issue in Plaid link

### DIFF
--- a/PlaidLink.tsx
+++ b/PlaidLink.tsx
@@ -104,7 +104,7 @@ export default function PlaidLink({
   return (
     <WebView
       source={{
-        uri: `https://cdn.plaid.com/link/v2/stable/link.html?isWebView=true&token=${linkToken}`,
+        uri: `https://cdn.plaid.com/link/v2/stable/link.html?isWebview=true&token=${linkToken}`,
       }}
       ref={(ref) => (webviewRef = ref)}
       originWhitelist={['https://*', 'plaidlink://*']}

--- a/PlaidLink.tsx
+++ b/PlaidLink.tsx
@@ -104,7 +104,7 @@ export default function PlaidLink({
   return (
     <WebView
       source={{
-        uri: `https://cdn.plaid.com/link/v2/stable/link.html?isWebview=true&token=${linkToken}`,
+        uri: `https://cdn.plaid.com/link/v2/stable/link.html?isWebView=true&token=${linkToken}`,
       }}
       ref={(ref) => (webviewRef = ref)}
       originWhitelist={['https://*', 'plaidlink://*']}

--- a/types.ts
+++ b/types.ts
@@ -46,7 +46,7 @@ export interface LinkExitMetadata {
   institution?: LinkInstitution
   linkSessionId: string
   requestId: string
-  metadataJson?: String
+  metadataJson?: string
 }
 
 export interface LinkError {
@@ -72,8 +72,8 @@ export enum LinkExitMetadataStatus {
 }
 
 export interface LinkInstitution {
-  id: String
-  name: String
+  id: string
+  name: string
 }
 
 export enum LinkErrorCode {
@@ -205,20 +205,18 @@ export interface LinkSuccess {
 export interface LinkSuccessMetadata {
   institution?: LinkInstitution
   accounts: LinkAccount[]
-  linkSessionId: String
-  metadataJson?: String
+  linkSessionId: string
+  metadataJson?: string
 }
 
 export interface LinkAccount {
-  id: String
-  name?: String
-  mask?: String
+  id: string
+  name?: string
+  mask?: string
   type: LinkAccountType
-  subtype: LinkAccountSubtype
+  subtype: LinkAccountSubtypes
   verificationStatus?: LinkAccountVerificationStatus
 }
-
-export interface LinkAccountSubtype {}
 
 enum LinkAccountType {
   CREDIT = 'credit',


### PR DESCRIPTION
Your code was helpful, many thanks

In understanding it I found a few problems and wanted to give back so others doesn't encounter the same problem

Problems encountered
- some types were `String` instead of `string`
- There was an unused type and enum
- The plaid url was named `view` instead of `View` which was causing it to break

Cheers