### PR TITLE
reload webview on error

### DIFF
--- a/PlaidLink.tsx
+++ b/PlaidLink.tsx
@@ -107,6 +107,7 @@ export default function PlaidLink({
         uri: `https://cdn.plaid.com/link/v2/stable/link.html?isWebview=true&token=${linkToken}`,
       }}
       ref={(ref) => (webviewRef = ref)}
+      onError={ () => webviewRef.reload() }
       originWhitelist={['https://*', 'plaidlink://*']}
       onShouldStartLoadWithRequest={handleNavigationStateChange}
     />


### PR DESCRIPTION
On android due to the slow loading times of the Plaid Link the error "net::ERR_UNKNOWN_URL_SCHEME" occurs, by reloading the webview I've been able to overcome this issue. 